### PR TITLE
added install_name_tool conditional in src/Makevars

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
       - [Ubuntu Dependencies](#ubuntu-dependencies)
       - [Red-Hat-based distributions Dependencies](#red-hat-based-distributions-dependencies)
       - [OS X](#os-x)
-- [Installing Conos as Docker Container](#installing-conos-as-docker-container)
-  * [Ready-to-run docker image](#ready-to-run-docker-image)
-  * [Building docker image on the fly](#building-docker-image-on-the-fly)
+  * [Installing Conos as Docker Container](#installing-conos-as-docker-container)
+    + [Ready-to-run docker image](#ready-to-run-docker-image)
+    + [Building docker image on the fly](#building-docker-image-on-the-fly)
 - [Usage example](#usage-example)
   * [Alignment of datasets](#alignment-of-datasets)
   * [Integration with ScanPy](#integration-with-scanpy)
@@ -71,13 +71,13 @@ yum install openssl-devel libcurl-devel
 
 It is possible to install pagoda2 and Conos on OS X, however some users have reported issues with OpenMP configuration. For instructions see [pagoda2](https://github.com/hms-dbmi/pagoda2#mac-dependencies) readme.
 
-## Installing Conos as Docker Container
+### Installing Conos as Docker Container
 
 If your system configuration is making it difficult to install Conos natively, an alternative way to get Conos running is through a docker container.
 
 **Note:** on OS X, Docker Machine has Memory and CPU limit. To control it, please check instructions either for [CLI](https://stackoverflow.com/questions/32834082/how-to-increase-docker-machine-memory-mac/32834453#32834453) or for [Docker Desktop](https://docs.docker.com/docker-for-mac/#advanced).
 
-### Ready-to-run docker image
+#### Ready-to-run docker image
 
 The docker distribution has the latest version and also includes the [Pagoda2 package](https://github.com/hms-dbmi/pagoda2). To start a docker container, first [install docker](https://docs.docker.com/install/) on your platform and then start the pagoda container with the following command in the shell:
 
@@ -92,7 +92,7 @@ The first time you run the command it will download several images so make sure 
 docker pull vpetukhov/conos:latest
 ```
 
-### Building docker image on the fly
+#### Building docker image on the fly
 
 If you want to build image by your own, download the [Dockerfile](https://github.com/hms-dbmi/conos/blob/master/dockers/Dockerfile) (available in this repo under `/dockers`) and run to following command to build it:
 ```

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Then install [pagoda2](https://github.com/hms-dbmi/pagoda2) (or Seurat), then in
 devtools::install_github("hms-dbmi/conos")
 ```
 
+If you have problems with `sccore` package, run `devtools::install_github("hms-dbmi/sccore")` before installing Conos.
+
 #### System dependencies
 
 The dependencies are inherited from [pagoda2](https://github.com/hms-dbmi/pagoda2):

--- a/dockers/Dockerfile
+++ b/dockers/Dockerfile
@@ -24,8 +24,9 @@ RUN apt-get update --yes && apt-get install --no-install-recommends --yes \
 
 RUN \
   R -e 'chooseCRANmirror(ind=52); install.packages(c("RcppEigen", "urltools", "Rtsne","BiocManager"))' && \
-  R -e 'install.packages("Seurat")' && \
-  R -e 'devtools::install_github("jlmelville/uwot")' && \
+  R -e 'install.packages("Seurat")'
+
+RUN \
   R -e 'devtools::install_github("hms-dbmi/pagoda2")' && \
   R -e 'BiocManager::install(c("GO.db", "org.Hs.eg.db","org.Mm.eg.db", "pcaMethods","DESeq2","BiocGenerics"), suppressUpdates=TRUE);' && \
-  R -e 'devtools::install_github("hms-dbmi/conos", ref="master")'
+  R -e 'devtools::install_github("hms-dbmi/conos")'

--- a/src/Makevars
+++ b/src/Makevars
@@ -4,7 +4,7 @@ PKG_CXXFLAGS= -I"../inst/include" -I"./n2/include" -I"./leidenalg/igraph-R" -I".
 PKGB_PATH=`echo 'library(igraph); cat(system.file("libs", package="igraph"))' \
       | ${R_HOME}/bin/R --vanilla --slave`
 
-PKG_LIBS=-L/usr/lib/ -L"." -lpthread -lstdc++ -ln2 -lleidenalg -lm `$(R_HOME)/bin/Rscript -e "Rcpp:::LdFlags()"` $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(SHLIB_OPENMP_CXXFLAGS) $(PKGB_PATH)/igraph$(DYLIB_EXT)
+PKG_LIBS=-L/usr/lib/ -L"." -lpthread -lstdc++ -ln2 -lleidenalg -lm `$(R_HOME)/bin/Rscript -e "Rcpp:::LdFlags()"` $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(SHLIB_OPENMP_CXXFLAGS) $(PKGB_PATH)/igraph.so
 CXX_STD = CXX11
 MkInclude = $(R_HOME)/etc${R_ARCH}/Makeconf
 
@@ -14,7 +14,10 @@ MkInclude = $(R_HOME)/etc${R_ARCH}/Makeconf
 SUBDIRS = n2 leidenalg
 SUBLIBS = libn2.a leidenalg.a
 
+IGRAPH_LIB = $(PKGB_PATH)/igraph.so
+
 all: $(SHLIB) 
+	if [ "$(OS)" != "Windows_NT" ] && [ `uname -s` = 'Darwin' ]; then install_name_tool -id '@rpath/igraph.so' $(IGRAPH_LIB); fi 
 $(SHLIB): $(OBJECTS) sublibs
 sublibs: sublibraries
 


### PR DESCRIPTION
(I'm not sure if you prefer PRs into master---we could use another branch)

Currently, this is my best solution for Mac OS users experiencing this issue:

https://github.com/hms-dbmi/conos/issues/11

R data.table does something similar, so it feels like a reasonable approach:
https://github.com/Rdatatable/data.table/blob/master/src/Makevars.in#L6

Works for me. 

************************

My current set-up:
R version 4.0.0 (not installed via brew)
Mac OS 10.15.4 Catalina
Installed LLVM and gcc via brew, i.e. `brew install llvm gcc`
and I included the following in my `~/.zshrc`:
```
export PATH="/usr/local/opt/llvm/bin:$PATH"
export LDFLAGS="-L/usr/local/opt/llvm/lib"
export CPPFLAGS="-I/usr/local/opt/llvm/include"

```
clang:
```
clang -v
clang version 10.0.0 
Target: x86_64-apple-darwin19.4.0
Thread model: posix
InstalledDir: /usr/local/opt/llvm/bin
```

Here is my `.R/Makevars`, explicitly settting the `-fopenmp` flags (which could be a problem for some packages installed from source...look into this):
```
XCBASE:=$(shell xcrun --show-sdk-path)
LLVMBASE:=$(shell brew --prefix llvm)
GCCBASE:=$(shell brew --prefix gcc)
GETTEXT:=$(shell brew --prefix gettext)

CC=$(LLVMBASE)/bin/clang -fopenmp
CXX=$(LLVMBASE)/bin/clang++ -fopenmp
CXX11=$(LLVMBASE)/bin/clang++ -fopenmp
CXX14=$(LLVMBASE)/bin/clang++ -fopenmp
CXX17=$(LLVMBASE)/bin/clang++ -fopenmp
CXX1X=$(LLVMBASE)/bin/clang++ -fopenmp

CPPFLAGS=-isystem "$(LLVMBASE)/include" -isysroot "$(XCBASE)"
LDFLAGS=-L"$(LLVMBASE)/lib" -L"$(GETTEXT)/lib" --sysroot="$(XCBASE)"

FC=$(GCCBASE)/bin/gfortran -fopenmp
F77=$(GCCBASE)/bin/gfortran -fopenmp
FLIBS=-L$(GCCBASE)/lib/gcc/9/ -lm
```

With the above, I was successfully able to install conos (and pagoda2). 



